### PR TITLE
🏷️ Override Bitbucket Cloud's schema to create new branches

### DIFF
--- a/src/cloud/client.test.ts
+++ b/src/cloud/client.test.ts
@@ -1,7 +1,20 @@
 import { test } from "vitest"
 import { createBitbucketCloudClient } from "./client.ts"
 
-test("createBitbucketCloudClient", ({ expect }) => {
+test("createBitbucketCloudClient", async ({ expect }) => {
 	const client = createBitbucketCloudClient()
 	expect(client).toBeDefined()
+
+	await client.POST("/repositories/{workspace}/{repo_slug}/refs/branches", {
+		params: {
+			path: {
+				repo_slug: "repo_slug",
+				workspace: "workspace",
+			},
+		},
+		body: {
+			name: "name",
+			target: { hash: "hash" },
+		},
+	})
 })

--- a/src/cloud/client.test.ts
+++ b/src/cloud/client.test.ts
@@ -1,20 +1,7 @@
 import { test } from "vitest"
 import { createBitbucketCloudClient } from "./client.ts"
 
-test("createBitbucketCloudClient", async ({ expect }) => {
+test("createBitbucketCloudClient", ({ expect }) => {
 	const client = createBitbucketCloudClient()
 	expect(client).toBeDefined()
-
-	await client.POST("/repositories/{workspace}/{repo_slug}/refs/branches", {
-		params: {
-			path: {
-				repo_slug: "repo_slug",
-				workspace: "workspace",
-			},
-		},
-		body: {
-			name: "name",
-			target: { hash: "hash" },
-		},
-	})
 })

--- a/src/cloud/client.ts
+++ b/src/cloud/client.ts
@@ -1,6 +1,6 @@
 import type { Client, ClientOptions } from "openapi-fetch"
 import createClient from "openapi-fetch"
-import type { paths } from "./openapi/index.ts"
+import type { paths } from "./interfaces/paths.ts"
 
 /**
  * Creates an `openapi-fetch` client using {@link createClient}.

--- a/src/cloud/index.ts
+++ b/src/cloud/index.ts
@@ -1,2 +1,3 @@
 export * from "./client.ts"
+export type * from "./interfaces/index.ts"
 export type * as OpenApi from "./openapi/index.ts"

--- a/src/cloud/interfaces/index.ts
+++ b/src/cloud/interfaces/index.ts
@@ -1,0 +1,1 @@
+export type * from "./paths.ts"

--- a/src/cloud/interfaces/paths.test.ts
+++ b/src/cloud/interfaces/paths.test.ts
@@ -1,0 +1,30 @@
+import { test } from "vitest"
+import { createBitbucketCloudClient } from "../client.js"
+import type { CreateBranchRequest } from "./paths.ts"
+
+async function fetch() {
+	const response = new Response(JSON.stringify({}), { status: 200 })
+	return Promise.resolve(response)
+}
+
+const client = createBitbucketCloudClient({
+	baseUrl: "https://api.bitbucket.org/2.0",
+	fetch,
+})
+
+test("CreateBranchRequest", async ({ expect }) => {
+	const example: CreateBranchRequest = {
+		name: "smf/create-feature",
+		target: { hash: "default" },
+	}
+
+	const { response } = await client.POST(
+		"/repositories/{workspace}/{repo_slug}/refs/branches",
+		{
+			params: { path: { repo_slug: "repo_slug", workspace: "workspace" } },
+			body: example,
+		},
+	)
+
+	expect(response.status).toBe(200)
+})

--- a/src/cloud/interfaces/paths.ts
+++ b/src/cloud/interfaces/paths.ts
@@ -1,0 +1,35 @@
+import type { paths as openapi } from "../openapi/openapi-typescript.ts"
+
+/**
+ * Overrides Bitbucket Cloud's OpenAPI schema.
+ */
+export interface paths
+	extends Omit<openapi, "/repositories/{workspace}/{repo_slug}/refs/branches"> {
+	readonly "/repositories/{workspace}/{repo_slug}/refs/branches": Omit<
+		openapi["/repositories/{workspace}/{repo_slug}/refs/branches"],
+		"post"
+	> & {
+		readonly post: Omit<
+			openapi["/repositories/{workspace}/{repo_slug}/refs/branches"]["post"],
+			"requestBody"
+		> & {
+			readonly requestBody: {
+				readonly content: {
+					readonly "application/json": CreateBranchRequest
+				}
+			}
+		}
+	}
+}
+
+/** Request to create a branch. */
+export interface CreateBranchRequest {
+	/** Name of the new branch */
+	readonly name: string
+	/** Where to point the new branch to */
+	readonly target: Target
+}
+
+export interface Target {
+	readonly hash: string
+}


### PR DESCRIPTION
<!-- Replace this by a short description under 60 characters -->

### 📝 Description

<!-- Why this pull request? -->

Bitbucket Cloud's documentation is as odd with its schema.

<!-- Why is this the best solution? -->

Overriding is the simplest way to get over it.

<!-- What you did -->

* Override in `"/repositories/{workspace}/{repo_slug}/refs/branches"` the `post`'s `requestBody` with a type taken straight from its docs.

### 📓 References

<!-- A list of links to discussions, documentation, issues, pull requests -->

* https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-get


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the branch creation API to provide a clearer, more robust structure for making branch requests via Bitbucket Cloud.
	- Expanded the available interface to support more resilient and integrated development experiences.
  
- **Tests**
	- Added automated tests to verify the successful operation of the branch creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->