### PR TITLE
Block fork pull request workflow jobs

### DIFF
--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   test:
+    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
 
     steps:
@@ -66,7 +67,7 @@ jobs:
     needs:
       - test
 
-    if: failure() && github.event_name != 'merge_group' && github.actor != 'github-actions[bot]' && github.actor != 'nektos/act'
+    if: ${{ (github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository) && (failure() && github.event_name != 'merge_group' && github.actor != 'github-actions[bot]' && github.actor != 'nektos/act') }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Skip GitHub Actions jobs for pull requests opened from forks.
- Keep push, merge queue, issue, and same-repository pull request behavior unchanged.

## Why
Public fork pull requests can run attacker-controlled workflow code. Skipping those jobs prevents those pull requests from reaching repository secrets through GitHub Actions.

## Validation
- Parsed the changed workflow files with `yq e '.'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow execution conditions to improve CI/CD pipeline reliability and consistency across different development scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coderabbitai/bitbucket/pull/123)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->